### PR TITLE
Add missing event names in documentation

### DIFF
--- a/docs/guide/testrunner/reporters.md
+++ b/docs/guide/testrunner/reporters.md
@@ -56,6 +56,7 @@ You can register event handler for several events which get triggered during the
 
 ```txt
 'start'
+'runner:start'
 'suite:start'
 'hook:start'
 'hook:end'
@@ -65,6 +66,7 @@ You can register event handler for several events which get triggered during the
 'test:fail'
 'test:pending'
 'suite:end'
+'runner:end'
 'end'
 ```
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

While digging into custom reporters, noticed that a couple of event names were missing from the documentation (not to mention that maybe the code examples could also be updated to utilize ES2015).

I was reading this file while noticed the missing events:

https://github.com/webdriverio/wdio-spec-reporter/blob/2fac52bdf03e60f750715a39eea778c5b63a3cb8/lib/reporter.js#L41

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
